### PR TITLE
fix: #11 Added CORS policy and removed refresh token as parameter fro…

### DIFF
--- a/src/Yana.Api/Configurations/AppConfiguration.cs
+++ b/src/Yana.Api/Configurations/AppConfiguration.cs
@@ -6,6 +6,7 @@ public static class AppConfiguration
     {
         if (app.Environment.IsDevelopment()) app.ConfigureSwagger();
 
+        app.ConfigureCors();
         app.UseHttpsRedirection();
         app.ConfigureAuthenticationAndAuthorization();
         app.MapControllers();
@@ -27,5 +28,10 @@ public static class AppConfiguration
     {
         app.UseAuthentication();
         app.UseAuthorization();
+    }
+
+    private static void ConfigureCors(this WebApplication app)
+    {
+        app.UseCors("YanaLocalDevelopmentFrontend");
     }
 }

--- a/src/Yana.Api/Configurations/BuilderConfiguration.cs
+++ b/src/Yana.Api/Configurations/BuilderConfiguration.cs
@@ -18,6 +18,7 @@ internal static class BuilderConfiguration
         builder.ConfigureDataProtector();
         builder.ConfigureAuthenticationAndAuthorization();
 
+        builder.ConfigureCors();
         builder.ConfigureControllers();
         builder.ConfigureSwagger();
 
@@ -132,5 +133,26 @@ internal static class BuilderConfiguration
     private static void ConfigureMvc(WebApplicationBuilder builder)
     {
         builder.Services.AddMvc(options => { });
+    }
+
+    private static void ConfigureCors(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddCors(options =>
+        {
+            options.AddPolicy("YanaLocalDevelopmentFrontend", policy =>
+            {
+                policy.WithOrigins("http://localhost:3000")
+                    .AllowAnyMethod()
+                    .AllowAnyHeader();
+            });
+        });
+
+        builder.WebHost.ConfigureKestrel(options =>
+        {
+            options.ConfigureHttpsDefaults(httpsOptions =>
+            {
+                httpsOptions.AllowAnyClientCertificate(); // Development only
+            });
+        });
     }
 }

--- a/src/Yana.Api/Controllers/AuthController.cs
+++ b/src/Yana.Api/Controllers/AuthController.cs
@@ -11,17 +11,17 @@ public sealed class AuthController(IMediator mediator) : YanaControllerBase(medi
     [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
     [ActionName(nameof(RegisterGoogleUser))]
     [GoogleUser]
-    public async Task<ActionResult<UserVm>> RegisterGoogleUser(string refreshToken)
-        => await SendCommand<UserVm, RegisterGoogleUserCommand>(new RegisterGoogleUserCommand(AuthenticatedUser!, refreshToken));
+    public async Task<ActionResult<UserVm>> RegisterGoogleUser()
+        => await SendCommand<UserVm, RegisterGoogleUserCommand>(
+            new RegisterGoogleUserCommand(AuthenticatedUser!));
 
     [HttpPost("login/google")]
     [Produces("application/json")]
     [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
     [ActionName(nameof(LoginGoogleUser))]
     [AuthorizeUser]
-    public async Task<ActionResult<bool>> LoginGoogleUser(string refreshToken)
-        => await SendCommand<bool, LoginGoogleUserCommand>(new LoginGoogleUserCommand(AuthenticatedUser!,
-            refreshToken));
+    public async Task<ActionResult<bool>> LoginGoogleUser()
+        => await SendCommand<bool, LoginGoogleUserCommand>(new LoginGoogleUserCommand(AuthenticatedUser!));
 
     [HttpPost("refresh-token/google")]
     [Produces("application/json")]

--- a/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommand.cs
+++ b/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommand.cs
@@ -1,7 +1,7 @@
 ﻿namespace Yana.Application.Features.Auth.Command.LoginGoogleUser;
 
-public class LoginGoogleUserCommand(UserProfile user, string refreshToken) : Command<CommandResponse<bool>>
+public sealed class LoginGoogleUserCommand(UserProfile user)
+    : Command<CommandResponse<bool>>
 {
     public UserProfile User { get; } = user;
-    public string RefreshToken { get; } = refreshToken;
 }

--- a/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommandHandler.cs
+++ b/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommandHandler.cs
@@ -13,7 +13,7 @@ public class LoginGoogleUserCommandHandler : IRequestHandler<LoginGoogleUserComm
 
     public async Task<CommandResponse<bool>> Handle(LoginGoogleUserCommand request, CancellationToken cancellationToken)
     {
-        var result = await _tokenService.InsertRefreshToken(request.User.Id, request.RefreshToken, AuthProvider.Google);
+        var result = true; // TODO: Obtain new refresh token here
 
         if (!result)
         {

--- a/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommandValidator.cs
+++ b/src/Yana.Application/Features/Auth/Command/LoginGoogleUser/LoginGoogleUserCommandValidator.cs
@@ -4,8 +4,14 @@ public class LoginGoogleUserCommandValidator : AbstractValidator<LoginGoogleUser
 {
     public LoginGoogleUserCommandValidator()
     {
-        RuleFor(x => x.RefreshToken)
-            .NotEmpty()
-            .WithMessage("Refresh token must be provided");
+        RuleFor(x => x.User)
+            .NotNull();
+
+        RuleFor(x => x.User.Id)
+            .NotEmpty();
+
+        RuleFor(x => x.User.Email)
+            .EmailAddress()
+            .NotEmpty();
     }
 }

--- a/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommand.cs
+++ b/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommand.cs
@@ -1,7 +1,6 @@
 ﻿namespace Yana.Application.Features.Auth.Command.RegisterGoogleUser;
 
-public sealed class RegisterGoogleUserCommand(UserProfile user, string refreshToken) : Command<CommandResponse<UserVm>>
+public sealed class RegisterGoogleUserCommand(UserProfile user) : Command<CommandResponse<UserVm>>
 {
     public UserProfile User { get; } = user;
-    public string RefreshToken { get; set; } = refreshToken;
 }

--- a/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommandHandler.cs
+++ b/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommandHandler.cs
@@ -13,6 +13,7 @@ public sealed class RegisterGoogleUserCommandHandler
     public async Task<CommandResponse<UserVm>> Handle(RegisterGoogleUserCommand request,
         CancellationToken cancellationToken)
     {
+        var refreshToken = "asdf"; // TODO: Obtain new refresh token here
         var user = await _userRepositoryService.UpsertUser(
             new UserProfileDto(
                 ExternalId: request.User.ExternalUserProfiles.First(x => x.AuthProvider == AuthProvider.Google).Id,
@@ -21,7 +22,7 @@ public sealed class RegisterGoogleUserCommandHandler
                 LastName: request.User.LastName,
                 AuthProvider: AuthProvider.Google
             ),
-            request.RefreshToken
+            refreshToken
         );
 
         return new CommandResponse<UserVm>

--- a/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommandValidator.cs
+++ b/src/Yana.Application/Features/Auth/Command/RegisterGoogleUser/RegisterGoogleUserCommandValidator.cs
@@ -13,8 +13,5 @@ public class RegisterGoogleUserCommandValidator : AbstractValidator<RegisterGoog
         RuleFor(x => x.User.Email)
             .EmailAddress()
             .NotEmpty();
-
-        RuleFor(x => x.RefreshToken)
-            .NotEmpty();
     }
 }


### PR DESCRIPTION
Closes #11 

## Intended changes
Add CORS policy and remove refresh token from login adn register endpoitns

## Non-Functional requirements
- API responses should be less than 500 ms
- Proper logging added for information and higher levels
- Endpoints must enfore strict authorization rules using JWT Bearer tokens
- System must only grant minimum permissions required

## Definition of done
- Acceptance criteria is met
- Non-functional requirements met
- Unit and integration tests passed

## Checklist
- [ ] Unit and/or integration tests have been written/updated
- [x] Warnings have been removed
- [x] DoD is satisfied
