### PR TITLE
Feature/28 endpoint for saving tile in document

### DIFF
--- a/src/Yana.Api/Base/YanaControllerBase.cs
+++ b/src/Yana.Api/Base/YanaControllerBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace Yana.Api.Base;
 
-[Route("api/[controller]")]
+[Route("api/[controller]s")]
 [ApiConventionType(typeof(SwaggerApiConvention))]
 [ApiController]
 public abstract class YanaControllerBase(IMediator mediator) : ControllerBase

--- a/src/Yana.Api/Controllers/AuthController.cs
+++ b/src/Yana.Api/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using Yana.Application.Features.Auth.Query.RefreshGoogleToken;
 
 namespace Yana.Api.Controllers;
 
+[Route("api/[controller]")]
 public sealed class AuthController(IMediator mediator) : YanaControllerBase(mediator)
 {
     [HttpPost("register/google")]

--- a/src/Yana.Api/Controllers/DocumentController.cs
+++ b/src/Yana.Api/Controllers/DocumentController.cs
@@ -1,0 +1,12 @@
+﻿namespace Yana.Api.Controllers;
+
+[AuthorizeUser]
+public sealed class DocumentController(IMediator mediator) : YanaControllerBase(mediator)
+{
+    [HttpPost("{documentId}/tiles/{tileId}/save")]
+    [Produces("application/json")]
+    [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
+    [ActionName(nameof(SaveTile))]
+    public async Task<ActionResult<bool>> SaveTile(string documentId, string tileId, SaveTileDto dto)
+        => await SendCommand<bool, SaveTileCommand>(new SaveTileCommand(documentId, tileId, dto));
+}

--- a/src/Yana.Api/Controllers/DocumentController.cs
+++ b/src/Yana.Api/Controllers/DocumentController.cs
@@ -1,4 +1,7 @@
-﻿namespace Yana.Api.Controllers;
+﻿using Yana.Application.Contracts.DocumentService;
+using Yana.Application.Features.Document.Command.CreateDocument;
+
+namespace Yana.Api.Controllers;
 
 [AuthorizeUser]
 public sealed class DocumentController(IMediator mediator) : YanaControllerBase(mediator)
@@ -9,4 +12,11 @@ public sealed class DocumentController(IMediator mediator) : YanaControllerBase(
     [ActionName(nameof(SaveTile))]
     public async Task<ActionResult<bool>> SaveTile(string documentId, string tileId, SaveTileDto dto)
         => await SendCommand<bool, SaveTileCommand>(new SaveTileCommand(documentId, tileId, dto));
+
+    [HttpPost("create")]
+    [Produces("application/json")]
+    [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
+    [ActionName(nameof(CreateDocument))]
+    public async Task<ActionResult<DocumentVm>> CreateDocument(DocumentDto dto)
+        => await SendCommand<DocumentVm, CreateDocumentCommand>(new CreateDocumentCommand(AuthenticatedUser!, dto));
 }

--- a/src/Yana.Api/Usings.cs
+++ b/src/Yana.Api/Usings.cs
@@ -12,6 +12,7 @@ global using Yana.Api.Swagger.SwaggerApiConvention;
 global using Yana.Application.Common;
 global using Yana.Application;
 global using Yana.Application.Features.User.Query.GetUserById;
+global using Yana.Application.Features.Document.Command.SaveTile;
 global using Yana.Application.ViewModels;
 global using Yana.Domain.Entites;
 global using Yana.Infrastructure;

--- a/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
+++ b/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
@@ -1,3 +1,5 @@
 ﻿namespace Yana.Application.Contracts.DocumentService;
 
-public sealed record DocumentDto(DocumentType Type, string Title);
+public sealed record DocumentDto(DocumentType Type, string Title, ICollection<TagDto> Tags);
+
+public sealed record TagDto(string Name);

--- a/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
+++ b/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
@@ -2,4 +2,4 @@
 
 public sealed record DocumentDto(DocumentType Type, string Title, ICollection<TagDto> Tags);
 
-public sealed record TagDto(string Name);
+public sealed record TagDto(int Id);

--- a/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
+++ b/src/Yana.Application/Contracts/DocumentService/DocumentDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Yana.Application.Contracts.DocumentService;
+
+public sealed record DocumentDto(DocumentType Type, string Title);

--- a/src/Yana.Application/Contracts/DocumentService/IDocumentRepositoryService.cs
+++ b/src/Yana.Application/Contracts/DocumentService/IDocumentRepositoryService.cs
@@ -3,4 +3,6 @@
 public interface IDocumentRepositoryService
 {
     public Task<bool> HasUserDocumentPermission(UserProfile user, string documentId, DocumentRole minimumRole);
+    public Task<Document?> GetDocument(string documentId);
+    public Task CreateDocument(DocumentDto dto);
 }

--- a/src/Yana.Application/Contracts/DocumentService/IDocumentRepositoryService.cs
+++ b/src/Yana.Application/Contracts/DocumentService/IDocumentRepositoryService.cs
@@ -4,5 +4,5 @@ public interface IDocumentRepositoryService
 {
     public Task<bool> HasUserDocumentPermission(UserProfile user, string documentId, DocumentRole minimumRole);
     public Task<Document?> GetDocument(string documentId);
-    public Task CreateDocument(DocumentDto dto);
+    public Task<Document> CreateDocument(UserProfile user, DocumentDto dto);
 }

--- a/src/Yana.Application/Contracts/TagService/ITagRepositoryService.cs
+++ b/src/Yana.Application/Contracts/TagService/ITagRepositoryService.cs
@@ -1,0 +1,6 @@
+﻿namespace Yana.Application.Contracts.TagService;
+
+public interface ITagRepositoryService
+{
+    public Task<ICollection<Tag>> GetTags(ICollection<int> tagIds);
+}

--- a/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
+++ b/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
@@ -3,5 +3,5 @@
 public interface ITileRepositoryService
 {
     public Task<Tile?> GetTile(string tileId);
-    public Task<bool> SaveTile(SaveTileDto dto);
+    public Task<bool> SaveTile(TileDto dto);
 }

--- a/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
+++ b/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
@@ -1,0 +1,7 @@
+﻿namespace Yana.Application.Contracts.TileService;
+
+public interface ITileRepositoryService
+{
+    public Task<Tile?> GetTile(string tileId);
+    public Task<bool> SaveTile(TileDto dto);
+}

--- a/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
+++ b/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
@@ -3,5 +3,5 @@
 public interface ITileRepositoryService
 {
     public Task<Tile?> GetTile(string tileId);
-    public Task<bool> SaveTile(TileDto dto);
+    public Task<bool> SaveTile(SaveTileDto dto);
 }

--- a/src/Yana.Application/Contracts/TileService/TileDto.cs
+++ b/src/Yana.Application/Contracts/TileService/TileDto.cs
@@ -1,3 +1,16 @@
 ﻿namespace Yana.Application.Contracts.TileService;
 
-public sealed record TileDto(string Id, string Content, string DocumentId);
+public record TileDto(string Id, string Content, string DocumentId);
+
+public sealed record SaveTileDto(
+    string Id,
+    string Content,
+    string DocumentId,
+    TileLayout LargeLayout,
+    TileLayout MediumLayout,
+    TileLayout SmallLayout,
+    TileLayout XSmallLayout,
+    TileLayout XxSmallLayout
+) : TileDto(Id, Content, DocumentId);
+
+public sealed record TileLayout(int XPosition, int YPosition, int Width, int Height);

--- a/src/Yana.Application/Contracts/TileService/TileDto.cs
+++ b/src/Yana.Application/Contracts/TileService/TileDto.cs
@@ -1,16 +1,23 @@
 ﻿namespace Yana.Application.Contracts.TileService;
 
-public record TileDto(string Id, string Content, string DocumentId);
-
-public sealed record SaveTileDto(
-    string Id,
+public abstract record TileDtoBase(
     string Content,
-    string DocumentId,
     TileLayout LargeLayout,
     TileLayout MediumLayout,
     TileLayout SmallLayout,
     TileLayout XSmallLayout,
     TileLayout XxSmallLayout
-) : TileDto(Id, Content, DocumentId);
+);
+
+public record TileDto(
+    string Id,
+    string DocumentId,
+    string Content,
+    TileLayout LargeLayout,
+    TileLayout MediumLayout,
+    TileLayout SmallLayout,
+    TileLayout XSmallLayout,
+    TileLayout XxSmallLayout
+) : TileDtoBase(Content, LargeLayout, MediumLayout, SmallLayout, XSmallLayout, XxSmallLayout);
 
 public sealed record TileLayout(int XPosition, int YPosition, int Width, int Height);

--- a/src/Yana.Application/Contracts/TileService/TileDto.cs
+++ b/src/Yana.Application/Contracts/TileService/TileDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Yana.Application.Contracts.TileService;
+
+public sealed record TileDto(string Id, string Content, string DocumentId);

--- a/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommand.cs
+++ b/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace Yana.Application.Features.Document.Command.CreateDocument;
+
+public sealed class CreateDocumentCommand(UserProfile user, DocumentDto dto) : Command<CommandResponse<DocumentVm>>
+{
+    public UserProfile User { get; set; } = user;
+    public DocumentDto Dto { get; set; } = dto;
+}

--- a/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandHandler.cs
+++ b/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandHandler.cs
@@ -1,8 +1,6 @@
-﻿using System.Runtime.InteropServices.ComTypes;
+﻿namespace Yana.Application.Features.Document.Command.CreateDocument;
 
-namespace Yana.Application.Features.Document.Command.CreateDocument;
-
-public class CreateDocumentCommandHandler : IRequestHandler<CreateDocumentCommand, CommandResponse<DocumentVm>>
+public sealed class CreateDocumentCommandHandler : IRequestHandler<CreateDocumentCommand, CommandResponse<DocumentVm>>
 {
     private readonly IDocumentRepositoryService _documentRepositoryService;
 

--- a/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandHandler.cs
+++ b/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandHandler.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.InteropServices.ComTypes;
+
+namespace Yana.Application.Features.Document.Command.CreateDocument;
+
+public class CreateDocumentCommandHandler : IRequestHandler<CreateDocumentCommand, CommandResponse<DocumentVm>>
+{
+    private readonly IDocumentRepositoryService _documentRepositoryService;
+
+    public CreateDocumentCommandHandler(IDocumentRepositoryService documentRepositoryService)
+    {
+        _documentRepositoryService = documentRepositoryService;
+    }
+
+    public async Task<CommandResponse<DocumentVm>> Handle(CreateDocumentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var document = await _documentRepositoryService.CreateDocument(request.User, request.Dto);
+        return new CommandResponse<DocumentVm>()
+        {
+            Result = new DocumentVm(
+                Id: document.Id,
+                Title: document.Title,
+                Tags: document.Tags.Select(x => new TagVm(x.Id, x.Name)).ToList(),
+                Tiles: document.Tiles.Select(x => new TileVm(
+                    TileId: x.Id,
+                    Content: x.Content,
+                    TileLayouts: x.DocumentLayouts
+                        .Select(y => new LayoutVm(
+                            LayoutSize: y.LayoutSize,
+                            XPosition: y.XPosition,
+                            YPosition: y.YPosition,
+                            Width: y.Width,
+                            Height: y.Height
+                        ))
+                        .ToList()
+                )).ToList()
+            )
+        };
+    }
+}

--- a/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandValidator.cs
+++ b/src/Yana.Application/Features/Document/Command/CreateDocument/CreateDocumentCommandValidator.cs
@@ -1,0 +1,8 @@
+﻿namespace Yana.Application.Features.Document.Command.CreateDocument;
+
+public class CreateDocumentCommandValidator : AbstractValidator<CreateDocumentCommand>
+{
+    public CreateDocumentCommandValidator()
+    {
+    }
+}

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommand.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommand.cs
@@ -1,0 +1,8 @@
+﻿using Yana.Application.Contracts.TileService;
+
+namespace Yana.Application.Features.Document.Command.SaveTile;
+
+public sealed class SaveTileCommand : Command<CommandResponse<bool>>
+{
+    public SaveTileDto Dto { get; set; } = null!;
+}

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommand.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommand.cs
@@ -1,8 +1,17 @@
-﻿using Yana.Application.Contracts.TileService;
+﻿namespace Yana.Application.Features.Document.Command.SaveTile;
 
-namespace Yana.Application.Features.Document.Command.SaveTile;
-
-public sealed class SaveTileCommand : Command<CommandResponse<bool>>
+public class SaveTileCommand(string documentId, string tileId, SaveTileDto dto) : Command<CommandResponse<bool>>
 {
-    public SaveTileDto Dto { get; set; } = null!;
-}
+    public string DocumentId { get; init; } = documentId;
+    public string TileId { get; init; } = tileId;
+    public SaveTileDto Dto { get; init; } = dto;
+};
+
+public record SaveTileDto(
+    string Content,
+    TileLayout LargeLayout,
+    TileLayout MediumLayout,
+    TileLayout SmallLayout,
+    TileLayout XSmallLayout,
+    TileLayout XxSmallLayout
+) : TileDtoBase(Content, LargeLayout, MediumLayout, SmallLayout, XSmallLayout, XxSmallLayout);

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandHandler.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandHandler.cs
@@ -1,0 +1,22 @@
+﻿namespace Yana.Application.Features.Document.Command.SaveTile;
+
+public class SaveTileCommandHandler : IRequestHandler<SaveTileCommand, CommandResponse<bool>>
+{
+    private readonly ITileRepositoryService _tileRepositoryService;
+
+    public SaveTileCommandHandler(IDocumentRepositoryService documentRepositoryService,
+        ITileRepositoryService tileRepositoryService)
+    {
+        _tileRepositoryService = tileRepositoryService;
+    }
+
+    public async Task<CommandResponse<bool>> Handle(SaveTileCommand request, CancellationToken cancellationToken)
+    {
+        var result = await _tileRepositoryService.SaveTile(request.Dto);
+
+        return new CommandResponse<bool>()
+        {
+            Result = result
+        };
+    }
+}

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandHandler.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandHandler.cs
@@ -12,7 +12,16 @@ public class SaveTileCommandHandler : IRequestHandler<SaveTileCommand, CommandRe
 
     public async Task<CommandResponse<bool>> Handle(SaveTileCommand request, CancellationToken cancellationToken)
     {
-        var result = await _tileRepositoryService.SaveTile(request.Dto);
+        var result = await _tileRepositoryService.SaveTile(new TileDto(
+            request.TileId,
+            request.DocumentId,
+            request.Dto.Content,
+            request.Dto.LargeLayout,
+            request.Dto.MediumLayout,
+            request.Dto.SmallLayout,
+            request.Dto.XSmallLayout,
+            request.Dto.XxSmallLayout)
+        );
 
         return new CommandResponse<bool>()
         {

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandValidator.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandValidator.cs
@@ -4,20 +4,20 @@ public class SaveTileCommandValidator : AbstractValidator<SaveTileCommand>
 {
     public SaveTileCommandValidator()
     {
+        RuleFor(x => x.TileId)
+            .NotEmpty()
+            .WithMessage("Tile ID cannot be null or empty");
+
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .WithMessage("Document ID cannot be null or empty");
+
         RuleFor(x => x.Dto)
             .ChildRules(y =>
             {
-                y.RuleFor(z => z.Id)
-                    .NotEmpty()
-                    .WithMessage("ID cannot be null or empty");
-
                 y.RuleFor(z => z.Content)
                     .NotNull()
                     .WithMessage("Content cannont have a null value");
-
-                y.RuleFor(z => z.DocumentId)
-                    .NotEmpty()
-                    .WithMessage("Document ID cannot be null or empty");
 
                 y.RuleFor(z => z.LargeLayout)
                     .NotNull()

--- a/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandValidator.cs
+++ b/src/Yana.Application/Features/Document/Command/SaveTile/SaveTileCommandValidator.cs
@@ -1,0 +1,44 @@
+﻿namespace Yana.Application.Features.Document.Command.SaveTile;
+
+public class SaveTileCommandValidator : AbstractValidator<SaveTileCommand>
+{
+    public SaveTileCommandValidator()
+    {
+        RuleFor(x => x.Dto)
+            .ChildRules(y =>
+            {
+                y.RuleFor(z => z.Id)
+                    .NotEmpty()
+                    .WithMessage("ID cannot be null or empty");
+
+                y.RuleFor(z => z.Content)
+                    .NotNull()
+                    .WithMessage("Content cannont have a null value");
+
+                y.RuleFor(z => z.DocumentId)
+                    .NotEmpty()
+                    .WithMessage("Document ID cannot be null or empty");
+
+                y.RuleFor(z => z.LargeLayout)
+                    .NotNull()
+                    .WithMessage($"Large layout cannot be null");
+
+                y.RuleFor(z => z.MediumLayout)
+                    .NotNull()
+                    .WithMessage($"Medium layout cannot be null");
+
+                y.RuleFor(z => z.SmallLayout)
+                    .NotNull()
+                    .WithMessage($"Small layout cannot be null");
+
+                y.RuleFor(z => z.XSmallLayout)
+                    .NotNull()
+                    .WithMessage($"XSmall layout cannot be null");
+
+                y.RuleFor(z => z.XxSmallLayout)
+                    .NotNull()
+                    .WithMessage($"XXSmall layout cannot be null");
+            })
+            .NotEmpty();
+    }
+}

--- a/src/Yana.Application/Usings.cs
+++ b/src/Yana.Application/Usings.cs
@@ -9,3 +9,5 @@ global using Yana.Application.Common;
 global using Yana.Domain.Entites;
 global using Yana.Domain.Enums;
 global using Yana.Application.Contracts.UserService;
+global using Yana.Application.Contracts.DocumentService;
+global using Yana.Application.Contracts.TileService;

--- a/src/Yana.Application/ViewModels/DocumentVm.cs
+++ b/src/Yana.Application/ViewModels/DocumentVm.cs
@@ -1,0 +1,3 @@
+﻿namespace Yana.Application.ViewModels;
+
+public sealed record DocumentVm(string Id, string Title, ICollection<TagVm> Tags, ICollection<TileVm> Tiles);

--- a/src/Yana.Application/ViewModels/TagVm.cs
+++ b/src/Yana.Application/ViewModels/TagVm.cs
@@ -1,0 +1,3 @@
+﻿namespace Yana.Application.ViewModels;
+
+public record TagVm(int Id, string Name);

--- a/src/Yana.Application/ViewModels/TileVm.cs
+++ b/src/Yana.Application/ViewModels/TileVm.cs
@@ -1,0 +1,5 @@
+﻿namespace Yana.Application.ViewModels;
+
+public record TileVm(string TileId, string? Content, ICollection<LayoutVm> TileLayouts);
+
+public record LayoutVm(LayoutSize LayoutSize, int XPosition, int YPosition, int Width, int Height);

--- a/src/Yana.Domain/Entites/Document.cs
+++ b/src/Yana.Domain/Entites/Document.cs
@@ -3,11 +3,12 @@
 public class Document
 {
     public string Id { get; init; } = Guid.NewGuid().ToString();
+    public string Title { get; set; } = null!;
     public DocumentType Type { get; set; }
-    public GridSize GridSize { get; set; }
-    public DateTime CreatedDate { get; set; } = DateTime.Now;
+    public DateTime CreatedDate { get; init; } = DateTime.Now;
 
     public virtual ICollection<UserProfile> Users { get; set; } = new List<UserProfile>();
+    public virtual ICollection<DocumentHasUser> DocumentHasUsers { get; set; } = new List<DocumentHasUser>();
     public virtual ICollection<Tag> Tags { get; set; } = new List<Tag>();
     public virtual ICollection<Document> ParentDocuments { get; set; } = new List<Document>();
     public virtual ICollection<Document> ChildDocuments { get; set; } = new List<Document>();

--- a/src/Yana.Domain/Entites/DocumentHasUser.cs
+++ b/src/Yana.Domain/Entites/DocumentHasUser.cs
@@ -5,7 +5,7 @@ public class DocumentHasUser
     public string DocumentId { get; set; } = null!;
     public string UserId { get; set; } = null!;
     public DocumentRole Role { get; set; }
-    public DateTime CreatedDate { get; set; }
+    public DateTime AddedDate { get; init; } = DateTime.Now;
     public DateTime UpdatedDate { get; set; }
 
     public virtual Document Document { get; set; } = null!;

--- a/src/Yana.Domain/Entites/Tag.cs
+++ b/src/Yana.Domain/Entites/Tag.cs
@@ -4,7 +4,7 @@ public class Tag
 {
     public int Id { get; set; }
     public string Name { get; set; } = null!;
-    public DateTime DateCreated { get; set; }
+    public DateTime DateCreated { get; init; } = DateTime.Now;
 
     public virtual UserProfile UserProfile { get; set; } = null!;
     public virtual ICollection<Document> Documents { get; set; } = new List<Document>();

--- a/src/Yana.Domain/Entites/Tile.cs
+++ b/src/Yana.Domain/Entites/Tile.cs
@@ -4,7 +4,7 @@ public class Tile
 {
     public string Id { get; set; } = null!;
     public string? Content { get; set; }
-    public DateTime CreatedDate { get; set; } = DateTime.Now;
+    public DateTime CreatedDate { get; init; } = DateTime.Now;
 
     public virtual Document Document { get; set; } = null!;
     public virtual ICollection<UserProfile> Users { get; set; } = new List<UserProfile>();

--- a/src/Yana.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/Yana.Infrastructure/InfrastructureServiceRegistration.cs
@@ -1,4 +1,7 @@
-﻿namespace Yana.Infrastructure;
+﻿using Yana.Application.Contracts.TagService;
+using Yana.Infrastructure.Services.TagService;
+
+namespace Yana.Infrastructure;
 
 public static class InfrastructureServiceRegistration
 {
@@ -10,6 +13,7 @@ public static class InfrastructureServiceRegistration
         services.AddScoped<IAuthenticationService, GoogleAuthenticationService>();
         services.AddScoped<IDocumentRepositoryService, DocumentRepositoryService>();
         services.AddScoped<ITileRepositoryService, TileRepositoryService>();
+        services.AddScoped<ITagRepositoryService, TagRepositoryService>();
 
         // Third party services
         services.AddScoped<JwtSecurityTokenHandler>();

--- a/src/Yana.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/Yana.Infrastructure/InfrastructureServiceRegistration.cs
@@ -1,7 +1,4 @@
-﻿using System.IdentityModel.Tokens.Jwt;
-
-
-namespace Yana.Infrastructure;
+﻿namespace Yana.Infrastructure;
 
 public static class InfrastructureServiceRegistration
 {
@@ -12,6 +9,7 @@ public static class InfrastructureServiceRegistration
         services.AddScoped<IEncryptionService, EncryptionService>();
         services.AddScoped<IAuthenticationService, GoogleAuthenticationService>();
         services.AddScoped<IDocumentRepositoryService, DocumentRepositoryService>();
+        services.AddScoped<ITileRepositoryService, TileRepositoryService>();
 
         // Third party services
         services.AddScoped<JwtSecurityTokenHandler>();

--- a/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
@@ -20,15 +20,30 @@ public class DocumentRepositoryService : IDocumentRepositoryService
             .Include(x => x.DocumentHasUsers)
             .FirstOrDefaultAsync(x => x.Id == documentId);
 
-    public async Task CreateDocument(DocumentDto dto)
+    public async Task<Document> CreateDocument(UserProfile user, DocumentDto dto)
     {
         var document = new Document
         {
             Title = dto.Title,
-            Type = dto.Type
+            Type = dto.Type,
+            Tags = dto.Tags.Select(x => new Tag()
+                {
+                    Name = x.Name
+                })
+                .ToList(),
+            DocumentHasUsers =
+            [
+                new DocumentHasUser
+                {
+                    Role = DocumentRole.Owner
+                }
+            ],
+            Users = [user]
         };
 
         _dbContext.Documents.Add(document);
         await _dbContext.SaveChangesAsync();
+
+        return document;
     }
 }

--- a/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
@@ -1,12 +1,14 @@
 ﻿namespace Yana.Infrastructure.Services.DocumentService;
 
-public class DocumentRepositoryService : IDocumentRepositoryService
+public sealed class DocumentRepositoryService : IDocumentRepositoryService
 {
     private readonly YanaDbContext _dbContext;
+    private readonly ITagRepositoryService _tagRepositoryService;
 
-    public DocumentRepositoryService(YanaDbContext dbContext)
+    public DocumentRepositoryService(YanaDbContext dbContext, ITagRepositoryService tagRepositoryService)
     {
         _dbContext = dbContext;
+        _tagRepositoryService = tagRepositoryService;
     }
 
     public async Task<bool> HasUserDocumentPermission(UserProfile user, string documentId, DocumentRole minimumRole)
@@ -26,11 +28,7 @@ public class DocumentRepositoryService : IDocumentRepositoryService
         {
             Title = dto.Title,
             Type = dto.Type,
-            Tags = dto.Tags.Select(x => new Tag()
-                {
-                    Name = x.Name
-                })
-                .ToList(),
+            Tags = await _tagRepositoryService.GetTags(dto.Tags.Select(x => x.Id).ToList()),
             DocumentHasUsers =
             [
                 new DocumentHasUser

--- a/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
@@ -1,6 +1,4 @@
-﻿using Yana.Application.Contracts.DocumentService;
-
-namespace Yana.Infrastructure.Services.DocumentService;
+﻿namespace Yana.Infrastructure.Services.DocumentService;
 
 public class DocumentRepositoryService : IDocumentRepositoryService
 {
@@ -16,4 +14,21 @@ public class DocumentRepositoryService : IDocumentRepositoryService
             x.UserId == user.Id &&
             x.DocumentId == documentId &&
             x.Role >= minimumRole);
+
+    public async Task<Document?> GetDocument(string documentId)
+        => await _dbContext.Documents
+            .Include(x => x.DocumentHasUsers)
+            .FirstOrDefaultAsync(x => x.Id == documentId);
+
+    public async Task CreateDocument(DocumentDto dto)
+    {
+        var document = new Document
+        {
+            Title = dto.Title,
+            Type = dto.Type
+        };
+
+        _dbContext.Documents.Add(document);
+        await _dbContext.SaveChangesAsync();
+    }
 }

--- a/src/Yana.Infrastructure/Services/TIleService/TileRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/TIleService/TileRepositoryService.cs
@@ -1,0 +1,45 @@
+﻿using Yana.Application.Contracts.TileService;
+
+namespace Yana.Infrastructure.Services.TIleService;
+
+public sealed class TileRepositoryService : ITileRepositoryService
+{
+    private readonly YanaDbContext _dbContext;
+    private readonly IDocumentRepositoryService _documentRepositoryService;
+
+    public TileRepositoryService(YanaDbContext dbContext, IDocumentRepositoryService documentRepositoryService)
+    {
+        _dbContext = dbContext;
+        _documentRepositoryService = documentRepositoryService;
+    }
+
+    public async Task<Tile?> GetTile(string tileId)
+        => await _dbContext.Tiles.FirstOrDefaultAsync(x => x.Id == tileId);
+
+
+    public async Task<bool> SaveTile(TileDto dto)
+    {
+        var document = await _documentRepositoryService.GetDocument(dto.DocumentId);
+        if (document is null) return false;
+
+        var tile = await GetTile(dto.Id);
+        switch (tile)
+        {
+            case null:
+                tile = new Tile
+                {
+                    Id = dto.Id,
+                    Content = dto.Content,
+                    Document = document
+                };
+                _dbContext.Tiles.Add(tile);
+                break;
+            case not null:
+                _dbContext.Tiles.Update(tile);
+                break;
+        }
+
+        await _dbContext.SaveChangesAsync();
+        return true;
+    }
+}

--- a/src/Yana.Infrastructure/Services/TagService/TagRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/TagService/TagRepositoryService.cs
@@ -1,0 +1,18 @@
+﻿using Yana.Application.Contracts.TagService;
+
+namespace Yana.Infrastructure.Services.TagService;
+
+public class TagRepositoryService : ITagRepositoryService
+{
+    private readonly YanaDbContext _dbContext;
+
+    public TagRepositoryService(YanaDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ICollection<Tag>> GetTags(ICollection<int> tagIds)
+        => await _dbContext.Tags
+            .Where(x => tagIds.Contains(x.Id))
+            .ToListAsync();
+}

--- a/src/Yana.Infrastructure/Services/TileService/TileRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/TileService/TileRepositoryService.cs
@@ -1,6 +1,6 @@
 ﻿using Yana.Application.Contracts.TileService;
 
-namespace Yana.Infrastructure.Services.TIleService;
+namespace Yana.Infrastructure.Services.TileService;
 
 public sealed class TileRepositoryService : ITileRepositoryService
 {
@@ -19,7 +19,7 @@ public sealed class TileRepositoryService : ITileRepositoryService
             .FirstOrDefaultAsync(x => x.Id == tileId);
 
 
-    public async Task<bool> SaveTile(SaveTileDto dto)
+    public async Task<bool> SaveTile(TileDto dto)
     {
         var document = await _documentRepositoryService.GetDocument(dto.DocumentId);
         if (document is null) return false;

--- a/src/Yana.Infrastructure/Usings.cs
+++ b/src/Yana.Infrastructure/Usings.cs
@@ -3,9 +3,9 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.Options;
 global using Google.Apis.Auth.OAuth2;
-
 global using Yana.Application.Contracts.UserService;
 global using Yana.Application.Contracts.EncryptionService;
+global using Yana.Application.Contracts.TagService;
 global using Yana.Application.Contracts.TokenService;
 global using Yana.Application.Contracts.AuthenticationService;
 global using Yana.Application.Contracts.DocumentService;

--- a/src/Yana.Infrastructure/Usings.cs
+++ b/src/Yana.Infrastructure/Usings.cs
@@ -1,7 +1,9 @@
-﻿global using Microsoft.Extensions.DependencyInjection;
+﻿global using System.IdentityModel.Tokens.Jwt;
+global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.Options;
 global using Google.Apis.Auth.OAuth2;
+
 global using Yana.Application.Contracts.UserService;
 global using Yana.Application.Contracts.EncryptionService;
 global using Yana.Application.Contracts.TokenService;
@@ -15,3 +17,5 @@ global using Yana.Infrastructure.Services.EncryptionService;
 global using Yana.Infrastructure.Services.TokenService;
 global using Yana.Infrastructure.Services.UserService;
 global using Yana.Infrastructure.Services.DocumentService;
+global using Yana.Application.Contracts.TileService;
+global using Yana.Infrastructure.Services.TileService;

--- a/src/Yana.Persistence/Configurations/DocumentConfiguration.cs
+++ b/src/Yana.Persistence/Configurations/DocumentConfiguration.cs
@@ -15,7 +15,7 @@ public class DocumentConfiguration : IEntityTypeConfiguration<Document>
         builder.Property(x => x.Type)
             .IsRequired();
 
-        builder.Property(x => x.GridSize)
+        builder.Property(x => x.Title)
             .IsRequired();
 
         builder.Property(x => x.CreatedDate)

--- a/src/Yana.Persistence/Migrations/20250302005746_UpdatedDocumentFields.Designer.cs
+++ b/src/Yana.Persistence/Migrations/20250302005746_UpdatedDocumentFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Yana.Persistence.Context;
 
@@ -11,9 +12,11 @@ using Yana.Persistence.Context;
 namespace Yana.Persistence.Migrations
 {
     [DbContext(typeof(YanaDbContext))]
-    partial class YanaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250302005746_UpdatedDocumentFields")]
+    partial class UpdatedDocumentFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Yana.Persistence/Migrations/20250302005746_UpdatedDocumentFields.cs
+++ b/src/Yana.Persistence/Migrations/20250302005746_UpdatedDocumentFields.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Yana.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatedDocumentFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GridSize",
+                table: "Documents");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "Documents",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "Documents");
+
+            migrationBuilder.AddColumn<int>(
+                name: "GridSize",
+                table: "Documents",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}


### PR DESCRIPTION
## Closes Issue

Mention the issue(s) this PR closes:  
`Closes #28 `

## Intended Changes

Briefly describe the changes introduced in this PR:
> Endpoints for saving tiles in a doucment, where the logic is supposed to be as following
> - Create tile if it does not exist in DB
> - Update existing tile if it exists in DB, this should create a new version in the temporal database

## Additional Changes

List any additional changes made in this PR:

- Added endpoint for creating a document which will result in the following logic: When a new document is created it **must** be saved in the database before a user can edit it.

## Non-Functional Requirements

Ensure that these non-functional requirements are met:

- [ ] ~~API responses should be less than 500 ms~~ Unable to test - need to complete more user stories
- [x] Proper logging added for information and higher levels
- [x] Endpoints must enfore strict authorization rules using JWT Bearer tokens
- [x] System must only grant minimum permissions required
- [x] Private resources need a valid JWT token *(required)*
- [x] Proper logging added for information and higher levels

## Definition of Done

Mark when this PR is considered complete:

- [x] Acceptance criteria is met *(required)*
- [x] Non-functional requirements met *(required)*
- [x] Unit, snapshot, and end-to-end tests passed

## Checklist for Code Conventions and Standards

Ensure these conditions are met before submitting the PR:

- [x] Warnings have been removed
