### PR TITLE
chore: #29 Added endpoint for deleting a tile within a document

### DIFF
--- a/src/Yana.Api/Controllers/DocumentController.cs
+++ b/src/Yana.Api/Controllers/DocumentController.cs
@@ -1,11 +1,19 @@
 ﻿using Yana.Application.Contracts.DocumentService;
 using Yana.Application.Features.Document.Command.CreateDocument;
+using Yana.Application.Features.Document.Command.DeleteTile;
 
 namespace Yana.Api.Controllers;
 
 [AuthorizeUser]
 public sealed class DocumentController(IMediator mediator) : YanaControllerBase(mediator)
 {
+    [HttpPost("create")]
+    [Produces("application/json")]
+    [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
+    [ActionName(nameof(CreateDocument))]
+    public async Task<ActionResult<DocumentVm>> CreateDocument(DocumentDto dto)
+        => await SendCommand<DocumentVm, CreateDocumentCommand>(new CreateDocumentCommand(AuthenticatedUser!, dto));
+
     [HttpPost("{documentId}/tiles/{tileId}/save")]
     [Produces("application/json")]
     [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
@@ -13,10 +21,11 @@ public sealed class DocumentController(IMediator mediator) : YanaControllerBase(
     public async Task<ActionResult<bool>> SaveTile(string documentId, string tileId, SaveTileDto dto)
         => await SendCommand<bool, SaveTileCommand>(new SaveTileCommand(documentId, tileId, dto));
 
-    [HttpPost("create")]
+
+    [HttpPost("{documentId}/tiles/{tileId}/delete")]
     [Produces("application/json")]
     [ApiConventionMethod(typeof(SwaggerApiConvention), nameof(SwaggerApiConvention.StatusResponseTypes))]
-    [ActionName(nameof(CreateDocument))]
-    public async Task<ActionResult<DocumentVm>> CreateDocument(DocumentDto dto)
-        => await SendCommand<DocumentVm, CreateDocumentCommand>(new CreateDocumentCommand(AuthenticatedUser!, dto));
+    [ActionName(nameof(DeleteTile))]
+    public async Task<ActionResult<bool>> DeleteTile(string documentId, string tileId)
+        => await SendCommand<bool, DeleteTileCommand>(new DeleteTileCommand(AuthenticatedUser!, documentId, tileId));
 }

--- a/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
+++ b/src/Yana.Application/Contracts/TileService/ITileRepositoryService.cs
@@ -4,4 +4,5 @@ public interface ITileRepositoryService
 {
     public Task<Tile?> GetTile(string tileId);
     public Task<bool> SaveTile(TileDto dto);
+    public Task<bool> DeleteTile(string doucmentId, string tileId);
 }

--- a/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommand.cs
+++ b/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace Yana.Application.Features.Document.Command.DeleteTile;
+
+public sealed class DeleteTileCommand(UserProfile user, string documentId, string tileId) : Command<CommandResponse<bool>>
+{
+    public UserProfile User { get; set; } = user;
+    public string DocumentId { get; set; } = documentId;
+    public string TileId { get; set; } = tileId;
+}

--- a/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommandHandler.cs
+++ b/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommandHandler.cs
@@ -1,0 +1,46 @@
+﻿namespace Yana.Application.Features.Document.Command.DeleteTile;
+
+public sealed class DeleteTileCommandHandler : IRequestHandler<DeleteTileCommand, CommandResponse<bool>>
+{
+    private readonly IDocumentRepositoryService _documentRepositoryService;
+    private readonly ITileRepositoryService _tileRepositoryService;
+
+    public DeleteTileCommandHandler(ITileRepositoryService tileRepositoryService,
+        IDocumentRepositoryService documentRepositoryService)
+    {
+        _tileRepositoryService = tileRepositoryService;
+        _documentRepositoryService = documentRepositoryService;
+    }
+
+
+    public async Task<CommandResponse<bool>> Handle(DeleteTileCommand request, CancellationToken cancellationToken)
+    {
+        var hasPermission = await _documentRepositoryService.HasUserDocumentPermission(
+            request.User,
+            request.DocumentId,
+            DocumentRole.Editor
+        );
+
+        if (!hasPermission)
+        {
+            return new CommandResponse<bool>()
+            {
+                ErrorCode = ErrorCode.Forbidden,
+                ErrorMessage =
+                    $"{request.User.Id} does not have permission to delete tile in the following document: {request.DocumentId}"
+            };
+        }
+
+        var result = await _tileRepositoryService.DeleteTile(request.DocumentId, request.TileId);
+        return result
+            ? new CommandResponse<bool>()
+            {
+                Result = result
+            }
+            : new CommandResponse<bool>()
+            {
+                ErrorCode = ErrorCode.NotFound,
+                ErrorMessage = $"Could not find tile {request.TileId} in document {request.DocumentId}"
+            };
+    }
+}

--- a/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommandValidator.cs
+++ b/src/Yana.Application/Features/Document/Command/DeleteTile/DeleteTileCommandValidator.cs
@@ -1,0 +1,19 @@
+﻿namespace Yana.Application.Features.Document.Command.DeleteTile;
+
+public sealed class DeleteTileCommandValidator : AbstractValidator<DeleteTileCommand>
+{
+    public DeleteTileCommandValidator()
+    {
+        RuleFor(x => x.User)
+            .NotNull()
+            .WithMessage("User must be provided. This could be due the the user not being logged in");
+
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .WithMessage("Document ID cannot be null or empty");
+
+        RuleFor(x => x.TileId)
+            .NotEmpty()
+            .WithMessage("Tile ID cannot be null or empty");
+    }
+}

--- a/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/DocumentService/DocumentRepositoryService.cs
@@ -20,6 +20,7 @@ public sealed class DocumentRepositoryService : IDocumentRepositoryService
     public async Task<Document?> GetDocument(string documentId)
         => await _dbContext.Documents
             .Include(x => x.DocumentHasUsers)
+            .Include(x => x.Tiles)
             .FirstOrDefaultAsync(x => x.Id == documentId);
 
     public async Task<Document> CreateDocument(UserProfile user, DocumentDto dto)

--- a/src/Yana.Infrastructure/Services/TileService/TileRepositoryService.cs
+++ b/src/Yana.Infrastructure/Services/TileService/TileRepositoryService.cs
@@ -55,6 +55,19 @@ public sealed class TileRepositoryService : ITileRepositoryService
         return true;
     }
 
+    public async Task<bool> DeleteTile(string documentId, string tileId)
+    {
+        var tile = (await _documentRepositoryService.GetDocument(documentId))?.Tiles
+            .FirstOrDefault(x => x.Id == tileId);
+
+        if (tile is null) return false;
+
+        _dbContext.Tiles.Remove(tile);
+        await _dbContext.SaveChangesAsync();
+
+        return true;
+    }
+
     private DocumentLayout ConvertTileLayoutToDocumentLayout(TileLayout tileLayout, LayoutSize layoutSize)
         => new()
         {


### PR DESCRIPTION
## Closes Issue

Mention the issue(s) this PR closes:  
`Closes #29 `

## Intended Changes

Briefly describe the changes introduced in this PR:
> Endpoint for deleting a tile within a document. A user need to have the proper role to be able to delete a tile

## Additional Changes

List any additional changes made in this PR:

- No additonal changes
## Non-Functional Requirements

Ensure that these non-functional requirements are met:

- [ ] ~~API responses should be less than 500 ms~~ Blocked by FE
- [x] Proper logging added for information and higher levels
- [x] Endpoints must enfore strict authorization rules using JWT Bearer tokens
- [x] System must only grant minimum permissions required
- [x] Private resources need a valid JWT token *(required)*
- [x] Proper logging added for information and higher levels

## Definition of Done

Mark when this PR is considered complete:

- [x] Acceptance criteria is met *(required)*
- [x] Non-functional requirements met *(required)*
- [x] Unit, snapshot, and end-to-end tests passed

## Checklist for Code Conventions and Standards

Ensure these conditions are met before submitting the PR:

- [x] Warnings have been removed
